### PR TITLE
Allow passing response from stdin in CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,22 +9,6 @@
 </p>
 
 <p align="center">
-    <a href="https://pypi.org/project/root-signals/">
-      <img alt="Supported Python versions" src="https://img.shields.io/badge/Python-3.10%20to%203.13-yellow?style=for-the-badge&logo=python&logoColor=yellow">
-    </a>
-</p>
-
-<p align="center">
-  <a href="https://pypi.org/project/root-signals">
-    <img src="https://img.shields.io/pypi/v/root-signals" alt="PyPI">
-  </a>
-  <img src="https://img.shields.io/pypi/dm/root-signals?color=orange" alt="Downloads">
-  <a href="https://github.com/root-signals/rs-python-sdk/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/root-signals/rs-python-sdk.svg" alt="License">
-  </a>
-</p>
-
-<p align="center">
   <a href="https://app.rootsignals.ai/register">
     <img src="https://img.shields.io/badge/Get_Started-2E6AFB?style=for-the-badge&logo=rocket&logoColor=white&scale=2" />
   </a>
@@ -169,6 +153,18 @@ roots judge execute <judge_id> --request "What is the capital of France?" --resp
 *   `--expected-output`: Expected output text.
 *   `--tag`: Add one or more tags.
 
+**Using stdin input:**
+
+You can pipe input directly to the `--response` parameter:
+
+```bash
+echo "Paris" | roots judge execute <judge_id> --request "What is the capital of France?"
+```
+
+```bash
+cat response.txt | roots judge execute <judge_id>
+```
+
 #### `execute-by-name`
 
 Execute a Judge by its name.
@@ -176,6 +172,9 @@ Execute a Judge by its name.
 ```bash
 roots judge execute-by-name "My New Judge" --request "What is the capital of France?" --response "Paris"
 ```
+
+Input can also be piped in similar way as with `execute`.
+
 
 
 ## Development

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -10,6 +10,7 @@
 
 import json
 import os
+import sys
 from typing import List, Optional, Union
 
 import click
@@ -322,7 +323,9 @@ def _execute_judge(
     judge_id, request, response, contexts_json, functions_json, expected_output, tags
 ):  # noqa: C901
     """Executes a judge."""
-    # Validate that at least one of request or response is provided
+    if not response and not sys.stdin.isatty():
+        response = sys.stdin.read().strip()
+
     if not request and not response:
         print_error("Either --request or --response must be provided.")
         return
@@ -363,7 +366,9 @@ def _execute_judge_by_name(
     judge_name, request, response, contexts_json, functions_json, expected_output, tags
 ):  # noqa: C901
     """Executes a judge by name."""
-    # Validate that at least one of request or response is provided
+    if not response and not sys.stdin.isatty():
+        response = sys.stdin.read().strip()
+
     if not request and not response:
         print_error("Either --request or --response must be provided.")
         return

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -12,7 +12,7 @@
 set -e
 
 # --- Configuration ---
-SOURCE_URL="https://app.rootsignals.ai/cli/cli.py"
+SOURCE_URL="https://sdk.rootsignals.ai/cli/cli.py"
 INSTALL_NAME="roots"
 INSTALL_DIR="/usr/local/bin"
 INSTALL_PATH="$INSTALL_DIR/$INSTALL_NAME"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "root-signals-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "CLI for the Root Signals API"
 authors = [
     {name = "Root Signals", email = "support@rootsignals.ai"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced judge execution commands to support providing input via standard input (stdin), allowing users to pipe text or file contents directly into the CLI.
* **Documentation**
  * Updated CLI documentation with examples on using standard input for judge execution commands.
* **Bug Fixes**
  * Ensured that when both a response flag and stdin input are provided, the response flag takes precedence.
* **Tests**
  * Added tests to verify correct handling of input from stdin and precedence of command-line flags. 
* **Chores**
  * Updated installation script to use a new download source URL for the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->