### PR TITLE
Fix fetching root evaluators without prompt

### DIFF
--- a/python/openapi.yaml
+++ b/python/openapi.yaml
@@ -557,18 +557,6 @@ paths:
         required: true
       tags:
       - evaluators
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EvaluatorRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/EvaluatorRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/EvaluatorRequest'
-        required: true
       security:
       - publicApiKey: []
       responses:
@@ -994,7 +982,6 @@ paths:
         name: judge_id
         schema:
           type: string
-          format: uuid
         required: true
       tags:
       - judges
@@ -1054,7 +1041,6 @@ paths:
         name: judge_id
         schema:
           type: string
-          format: uuid
         required: true
       - in: query
         name: rs_metadata
@@ -1078,7 +1064,6 @@ paths:
         name: judge_id
         schema:
           type: string
-          format: uuid
         required: true
       tags:
       - judges
@@ -1188,7 +1173,6 @@ paths:
         name: judge_id
         schema:
           type: string
-          format: uuid
         required: true
       - in: query
         name: rs_metadata
@@ -2057,7 +2041,6 @@ components:
         prompt:
           type: string
           maxLength: 100000
-          minLength: 2
         reference_variables:
           type: array
           items:
@@ -2543,7 +2526,7 @@ components:
             requests.
         prompt:
           type: string
-          minLength: 2
+          minLength: 1
           maxLength: 100000
         reference_variables:
           type: array
@@ -3815,7 +3798,7 @@ components:
             requests.
         prompt:
           type: string
-          minLength: 2
+          minLength: 1
           maxLength: 100000
         reference_variables:
           type: array

--- a/python/src/root/generated/openapi_aclient/api/evaluators_api.py
+++ b/python/src/root/generated/openapi_aclient/api/evaluators_api.py
@@ -976,7 +976,6 @@ class EvaluatorsApi:
     async def evaluators_duplicate_create(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -993,8 +992,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1018,12 +1015,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1040,7 +1032,6 @@ class EvaluatorsApi:
     async def evaluators_duplicate_create_with_http_info(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1057,8 +1048,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1082,12 +1071,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1104,7 +1088,6 @@ class EvaluatorsApi:
     async def evaluators_duplicate_create_without_preload_content(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1121,8 +1104,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1146,12 +1127,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1163,7 +1139,6 @@ class EvaluatorsApi:
     def _evaluators_duplicate_create_serialize(
         self,
         id,
-        evaluator_request,
         _request_auth,
         _content_type,
         _headers,
@@ -1187,21 +1162,9 @@ class EvaluatorsApi:
         # process the header parameters
         # process the form parameters
         # process the body parameter
-        if evaluator_request is not None:
-            _body_params = evaluator_request
 
         # set the HTTP header `Accept`
         _header_params["Accept"] = self.api_client.select_header_accept(["application/json"])
-
-        # set the HTTP header `Content-Type`
-        if _content_type:
-            _header_params["Content-Type"] = _content_type
-        else:
-            _default_content_type = self.api_client.select_header_content_type(
-                ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"]
-            )
-            if _default_content_type is not None:
-                _header_params["Content-Type"] = _default_content_type
 
         # authentication setting
         _auth_settings: List[str] = ["publicApiKey"]

--- a/python/src/root/generated/openapi_aclient/models/evaluator.py
+++ b/python/src/root/generated/openapi_aclient/models/evaluator.py
@@ -51,7 +51,7 @@ class Evaluator(BaseModel):
     name: Annotated[str, Field(min_length=2, strict=True, max_length=1000)]
     objective: Optional[Objective]
     owner: NestedUserDetails
-    prompt: Annotated[str, Field(min_length=2, strict=True, max_length=100000)]
+    prompt: Annotated[str, Field(strict=True, max_length=100000)]
     reference_variables: Optional[List[ReferenceVariable]] = None
     skill_type: SkillTypeEnum
     status: Optional[StatusEnum] = None

--- a/python/src/root/generated/openapi_aclient/models/evaluator_request.py
+++ b/python/src/root/generated/openapi_aclient/models/evaluator_request.py
@@ -50,7 +50,7 @@ class EvaluatorRequest(BaseModel):
     overwrite: Optional[StrictBool] = Field(
         default=False, description="Overwrite existing skill with the same name. Only for POST requests."
     )
-    prompt: Annotated[str, Field(min_length=2, strict=True, max_length=100000)]
+    prompt: Annotated[str, Field(min_length=1, strict=True, max_length=100000)]
     reference_variables: Optional[List[ReferenceVariableRequest]] = None
     status: Optional[StatusEnum] = None
     system_message: Optional[StrictStr] = None

--- a/python/src/root/generated/openapi_aclient/models/patched_evaluator_request.py
+++ b/python/src/root/generated/openapi_aclient/models/patched_evaluator_request.py
@@ -50,7 +50,7 @@ class PatchedEvaluatorRequest(BaseModel):
     overwrite: Optional[StrictBool] = Field(
         default=False, description="Overwrite existing skill with the same name. Only for POST requests."
     )
-    prompt: Optional[Annotated[str, Field(min_length=2, strict=True, max_length=100000)]] = None
+    prompt: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     reference_variables: Optional[List[ReferenceVariableRequest]] = None
     status: Optional[StatusEnum] = None
     system_message: Optional[StrictStr] = None

--- a/python/src/root/generated/openapi_client/api/evaluators_api.py
+++ b/python/src/root/generated/openapi_client/api/evaluators_api.py
@@ -976,7 +976,6 @@ class EvaluatorsApi:
     def evaluators_duplicate_create(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -993,8 +992,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1018,12 +1015,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1040,7 +1032,6 @@ class EvaluatorsApi:
     def evaluators_duplicate_create_with_http_info(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1057,8 +1048,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1082,12 +1071,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1104,7 +1088,6 @@ class EvaluatorsApi:
     def evaluators_duplicate_create_without_preload_content(
         self,
         id: StrictStr,
-        evaluator_request: EvaluatorRequest,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1121,8 +1104,6 @@ class EvaluatorsApi:
 
         :param id: (required)
         :type id: str
-        :param evaluator_request: (required)
-        :type evaluator_request: EvaluatorRequest
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1146,12 +1127,7 @@ class EvaluatorsApi:
         """  # noqa: E501
 
         _param = self._evaluators_duplicate_create_serialize(
-            id=id,
-            evaluator_request=evaluator_request,
-            _request_auth=_request_auth,
-            _content_type=_content_type,
-            _headers=_headers,
-            _host_index=_host_index,
+            id=id, _request_auth=_request_auth, _content_type=_content_type, _headers=_headers, _host_index=_host_index
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
@@ -1163,7 +1139,6 @@ class EvaluatorsApi:
     def _evaluators_duplicate_create_serialize(
         self,
         id,
-        evaluator_request,
         _request_auth,
         _content_type,
         _headers,
@@ -1187,21 +1162,9 @@ class EvaluatorsApi:
         # process the header parameters
         # process the form parameters
         # process the body parameter
-        if evaluator_request is not None:
-            _body_params = evaluator_request
 
         # set the HTTP header `Accept`
         _header_params["Accept"] = self.api_client.select_header_accept(["application/json"])
-
-        # set the HTTP header `Content-Type`
-        if _content_type:
-            _header_params["Content-Type"] = _content_type
-        else:
-            _default_content_type = self.api_client.select_header_content_type(
-                ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"]
-            )
-            if _default_content_type is not None:
-                _header_params["Content-Type"] = _default_content_type
 
         # authentication setting
         _auth_settings: List[str] = ["publicApiKey"]

--- a/python/src/root/generated/openapi_client/models/evaluator.py
+++ b/python/src/root/generated/openapi_client/models/evaluator.py
@@ -51,7 +51,7 @@ class Evaluator(BaseModel):
     name: Annotated[str, Field(min_length=2, strict=True, max_length=1000)]
     objective: Optional[Objective]
     owner: NestedUserDetails
-    prompt: Annotated[str, Field(min_length=2, strict=True, max_length=100000)]
+    prompt: Annotated[str, Field(strict=True, max_length=100000)]
     reference_variables: Optional[List[ReferenceVariable]] = None
     skill_type: SkillTypeEnum
     status: Optional[StatusEnum] = None

--- a/python/src/root/generated/openapi_client/models/evaluator_request.py
+++ b/python/src/root/generated/openapi_client/models/evaluator_request.py
@@ -50,7 +50,7 @@ class EvaluatorRequest(BaseModel):
     overwrite: Optional[StrictBool] = Field(
         default=False, description="Overwrite existing skill with the same name. Only for POST requests."
     )
-    prompt: Annotated[str, Field(min_length=2, strict=True, max_length=100000)]
+    prompt: Annotated[str, Field(min_length=1, strict=True, max_length=100000)]
     reference_variables: Optional[List[ReferenceVariableRequest]] = None
     status: Optional[StatusEnum] = None
     system_message: Optional[StrictStr] = None

--- a/python/src/root/generated/openapi_client/models/patched_evaluator_request.py
+++ b/python/src/root/generated/openapi_client/models/patched_evaluator_request.py
@@ -50,7 +50,7 @@ class PatchedEvaluatorRequest(BaseModel):
     overwrite: Optional[StrictBool] = Field(
         default=False, description="Overwrite existing skill with the same name. Only for POST requests."
     )
-    prompt: Optional[Annotated[str, Field(min_length=2, strict=True, max_length=100000)]] = None
+    prompt: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     reference_variables: Optional[List[ReferenceVariableRequest]] = None
     status: Optional[StatusEnum] = None
     system_message: Optional[StrictStr] = None


### PR DESCRIPTION
Root evaluators do not expose the prompt so we must allow empty prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts with a single character are now accepted in evaluator-related forms and requests.
* **Bug Fixes**
  * No longer requires a request body when duplicating an evaluator.
* **Refactor**
  * Judge-related endpoints now accept judge IDs in any string format, not just UUIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->