### PR TITLE
Release (py 1.6.4, ts 0.1.3, cli 0.1.4)

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "root-signals-cli"
-version = "0.1.3"
+version = "0.1.4"
 description = "CLI for the Root Signals API"
 authors = [
     {name = "Root Signals", email = "support@rootsignals.ai"},

--- a/python/docs/CHANGELOG.md
+++ b/python/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.4
+
+### Added
+
+- Status field to judges
+
 ## 1.6.3
 
 ### Added

--- a/python/src/root/__about__.py
+++ b/python/src/root/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present juho.ylikyla <juho.ylikyla@rootsignals.ai>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.6.3"
+__version__ = "1.6.4"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3
+
+### Added
+
+- Status field to judges
+
 ## 0.1.2
 
 ### Changed

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root-signals/typescript-sdk",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@root-signals/typescript-sdk",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.12.2"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root-signals/typescript-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for Root Signals API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added changelog entries for Python 1.6.4 and TypeScript 0.1.3, noting the addition of a “Status” field to judges.
- Chores
  - Bumped CLI version to 0.1.4.
  - Bumped Python package version to 1.6.4.
  - Bumped TypeScript SDK version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->